### PR TITLE
Add development/test container environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# ignore all files marked as hidden
+.*
+**/.*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+build:
+	docker-compose down
+	docker-compose up -d db fake-s3
+	docker-compose build
+	./mysql/wait_for_services & wait
+	docker-compose up app
+
+destroy:
+	docker-compose down --volumes
+
+.PHONY: build test destroy
+	

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ build:
 	./mysql/wait_for_services & wait
 	docker-compose up app
 
+test: build
+	./tests/test_backup_files_exist
+
 destroy:
 	docker-compose down --volumes
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,16 @@ Backups are scheduled to run nightly and target replica instances. This is in ad
 
 The backup script runs as a scheduled container task using Amazon ECS.
 
+## Getting started
+
+To build configure and run the application via docker-compose:
+
+`make build`
+
+To run tests:
+
+`make test`
+
 ## Environment Variables
 
 The following environment variables are required:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,9 @@ services:
 
   app:
     build: .
+    depends_on:
+     - db
+     - fake-s3
     environment:
       WIFI_DB_NAME: govwifi_test
       WIFI_DB_PASS: root
@@ -40,3 +43,6 @@ services:
       ADMIN_DB_USER: root
       ADMIN_DB_HOSTNAME: db
       S3_BUCKET: backup-bucket
+      AWS_ACCESS_KEY_ID: testkey
+      AWS_SECRET_ACCESS_KEY: testsecret
+      ENDPOINT_URL: "http://fake-s3:4572"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,8 +21,9 @@ services:
       - AWS_ACCESS_KEY_ID=testkey
       - AWS_SECRET_ACCESS_KEY=testsecret
     volumes:
-      - ./fake-s3:/tmp/localstack
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./fake-s3:/docker-entrypoint-initaws.d
+      - s3-data:/tmp/localstack
 
   app:
     build: .
@@ -34,15 +35,18 @@ services:
       WIFI_DB_PASS: root
       WIFI_DB_USER: root
       WIFI_DB_HOST: db
-      USER_DB_NAME: govwifi_test
-      USER_DB_PASS: root
-      USER_DB_USER: root
-      USER_DB_HOSTNAME: db
+      USERS_DB_NAME: govwifi_test
+      USERS_DB_PASS: root
+      USERS_DB_USER: root
+      USERS_DB_HOST: db
       ADMIN_DB_NAME: govwifi_test
       ADMIN_DB_PASS: root
       ADMIN_DB_USER: root
-      ADMIN_DB_HOSTNAME: db
+      ADMIN_DB_HOST: db
       S3_BUCKET: backup-bucket
       AWS_ACCESS_KEY_ID: testkey
       AWS_SECRET_ACCESS_KEY: testsecret
       ENDPOINT_URL: "http://fake-s3:4572"
+
+volumes:
+  s3-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,21 @@ services:
     expose:
       - "3306"
 
+  fake-s3:
+    image: localstack/localstack
+    ports:
+      - "4572:4572"
+      - "8080:8080"
+    environment:
+      - SERVICES=s3
+      - DOCKER_HOST=unix:///var/run/docker.sock
+      - DEFAULT_REGION=eu-west-1
+      - AWS_ACCESS_KEY_ID=testkey
+      - AWS_SECRET_ACCESS_KEY=testsecret
+    volumes:
+      - ./fake-s3:/tmp/localstack
+      - /var/run/docker.sock:/var/run/docker.sock
+
   app:
     build: .
     environment:
@@ -24,3 +39,4 @@ services:
       ADMIN_DB_PASS: root
       ADMIN_DB_USER: root
       ADMIN_DB_HOSTNAME: db
+      S3_BUCKET: backup-bucket

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3.4'
+
+services:
+  db:
+    build: ./mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: govwifi_test
+    expose:
+      - "3306"
+
+  app:
+    build: .
+    environment:
+      WIFI_DB_NAME: govwifi_test
+      WIFI_DB_PASS: root
+      WIFI_DB_USER: root
+      WIFI_DB_HOST: db
+      USER_DB_NAME: govwifi_test
+      USER_DB_PASS: root
+      USER_DB_USER: root
+      USER_DB_HOSTNAME: db
+      ADMIN_DB_NAME: govwifi_test
+      ADMIN_DB_PASS: root
+      ADMIN_DB_USER: root
+      ADMIN_DB_HOSTNAME: db

--- a/fake-s3/s3.sh
+++ b/fake-s3/s3.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+echo "Init localstack s3"
+awslocal s3 mb s3://backup-bucket

--- a/govwifi-backup.sh
+++ b/govwifi-backup.sh
@@ -4,11 +4,13 @@ set -eu
 
 echo "Starting backup of databases to S3..."
 
+ENDPOINT_ARG=${ENDPOINT_URL:+--endpoint-url=$ENDPOINT_URL}
+
 MYSQL_PWD="${WIFI_DB_PASS}" mysqldump \
   -h "${WIFI_DB_HOST}" -u "${WIFI_DB_USER}" \
   --set-gtid-purged=OFF --compress --quick --single-transaction \
   --no-create-info --complete-insert "${WIFI_DB_NAME}" \
-  | gzip -c | aws s3 cp - s3://"${S3_BUCKET}/wifi-backup-$(date -I)".sql.gz
+  | gzip -c | aws ${ENDPOINT_ARG} s3 cp - s3://"${S3_BUCKET}/wifi-backup-$(date -I)".sql.gz
 
 STATUS1=$?
 if [ $STATUS1 -eq 0 ] ; then echo OK ; else echo FAILED ; fi
@@ -17,7 +19,7 @@ MYSQL_PWD="${USERS_DB_PASS}" mysqldump \
   -h "${USERS_DB_HOST}" -u "${USERS_DB_USER}" \
   --set-gtid-purged=OFF --compress --quick --single-transaction \
   --no-create-info --complete-insert "${USERS_DB_NAME}" \
-  | gzip -c | aws s3 cp - s3://"${S3_BUCKET}/wifi-backup-user-details-$(date -I)".sql.gz
+  | gzip -c | aws ${ENDPOINT_ARG} s3 cp - s3://"${S3_BUCKET}/wifi-backup-user-details-$(date -I)".sql.gz
 
 STATUS2=$?
 if [ $STATUS2 -eq 0 ] ; then echo OK ; else echo FAILED ; fi
@@ -26,7 +28,7 @@ MYSQL_PWD="${ADMIN_DB_PASS}" mysqldump \
   -h "${ADMIN_DB_HOST}" -u "${ADMIN_DB_USER}" \
   --set-gtid-purged=OFF --compress --quick --single-transaction \
   --no-create-info --complete-insert "${ADMIN_DB_NAME}" \
-  | gzip -c | aws s3 cp - s3://"${S3_BUCKET}/wifi-backup-admin-$(date -I)".sql.gz
+  | gzip -c | aws ${ENDPOINT_ARG} s3 cp - s3://"${S3_BUCKET}/wifi-backup-admin-$(date -I)".sql.gz
 
 STATUS3=$?
 if [ $STATUS3 -eq 0 ] ; then echo OK ; else echo FAILED ; fi

--- a/govwifi-backup.sh
+++ b/govwifi-backup.sh
@@ -8,7 +8,7 @@ ENDPOINT_ARG=${ENDPOINT_URL:+--endpoint-url=$ENDPOINT_URL}
 
 MYSQL_PWD="${WIFI_DB_PASS}" mysqldump \
   -h "${WIFI_DB_HOST}" -u "${WIFI_DB_USER}" \
-  --set-gtid-purged=OFF --compress --quick --single-transaction \
+  --compress --quick --single-transaction \
   --no-create-info --complete-insert "${WIFI_DB_NAME}" \
   | gzip -c | aws ${ENDPOINT_ARG} s3 cp - s3://"${S3_BUCKET}/wifi-backup-$(date -I)".sql.gz
 
@@ -17,7 +17,7 @@ if [ $STATUS1 -eq 0 ] ; then echo OK ; else echo FAILED ; fi
 
 MYSQL_PWD="${USERS_DB_PASS}" mysqldump \
   -h "${USERS_DB_HOST}" -u "${USERS_DB_USER}" \
-  --set-gtid-purged=OFF --compress --quick --single-transaction \
+  --compress --quick --single-transaction \
   --no-create-info --complete-insert "${USERS_DB_NAME}" \
   | gzip -c | aws ${ENDPOINT_ARG} s3 cp - s3://"${S3_BUCKET}/wifi-backup-user-details-$(date -I)".sql.gz
 
@@ -26,7 +26,7 @@ if [ $STATUS2 -eq 0 ] ; then echo OK ; else echo FAILED ; fi
 
 MYSQL_PWD="${ADMIN_DB_PASS}" mysqldump \
   -h "${ADMIN_DB_HOST}" -u "${ADMIN_DB_USER}" \
-  --set-gtid-purged=OFF --compress --quick --single-transaction \
+  --compress --quick --single-transaction \
   --no-create-info --complete-insert "${ADMIN_DB_NAME}" \
   | gzip -c | aws ${ENDPOINT_ARG} s3 cp - s3://"${S3_BUCKET}/wifi-backup-admin-$(date -I)".sql.gz
 

--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -1,0 +1,3 @@
+FROM mysql:5.7
+
+ADD schema.sql /docker-entrypoint-initdb.d

--- a/mysql/schema.sql
+++ b/mysql/schema.sql
@@ -1,0 +1,50 @@
+-- MySQL dump 10.13  Distrib 5.7.21, for Linux (x86_64)
+--
+-- Database: govwifi_test
+-- ------------------------------------------------------
+-- Server version	5.7.16-log
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+
+DROP TABLE IF EXISTS `sessions`;
+
+CREATE TABLE `sessions` (
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `start` timestamp NULL DEFAULT NULL,
+  `stop` timestamp NULL DEFAULT NULL,
+  `siteIP` char(15) DEFAULT NULL,
+  `username` char(6) DEFAULT NULL,
+  `cert_name` varchar(64) DEFAULT NULL,
+  `mac` char(17) DEFAULT NULL,
+  `ap` char(17) DEFAULT NULL,
+  `building_identifier` varchar(20) DEFAULT NULL,
+  `success` BOOLEAN DEFAULT 1,
+  PRIMARY KEY (`id`),
+  KEY `siteIP` (`siteIP`,`username`),
+  KEY `sessions_username` (`username`),
+  KEY `sessions_start_username` (`start`,`username`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE `ip_locations` (
+  `ip` varchar(30) DEFAULT NULL,
+  `location_id` int(11) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+
+-- Dump completed on 2018-04-18 11:33:13sess

--- a/mysql/wait_for_services
+++ b/mysql/wait_for_services
@@ -1,0 +1,12 @@
+#!/bin/bash
+until docker-compose exec -T db mysql -hdb -uroot -proot -e 'SELECT 1' &> /dev/null
+do
+  printf "."
+  sleep 1
+done
+
+until docker-compose exec -T fake-s3 awslocal s3api head-bucket --bucket backup-bucket 2>/dev/null
+do
+  printf "."
+  sleep 1
+done

--- a/tests/test_backup_files_exist
+++ b/tests/test_backup_files_exist
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -euo pipefail
+
+FILES="$(docker-compose exec -T fake-s3 awslocal s3 ls s3://backup-bucket | awk '{ print $4 }')"
+COUNT=$(wc -w <<< ${FILES})
+
+if [ ${COUNT} -eq 3 ]; then
+  echo "SUCCESS: All backup files created (3):"
+  echo "${FILES}"
+  exit 0
+else
+  echo "FAILURE: Some backup files not created:"
+  echo "${FILES}"
+  exit 1
+fi


### PR DESCRIPTION
Uses docker-compose to run a local MySQL server and [localstack](https://github.com/localstack/localstack) fake s3 bucket. This allows the script to be configured to run in a test/CI environment.

* Adds a Makefile for easily starting/stopping containers in the correct order.
* Adds a simple test script to assert database backup files exist in the s3 bucket once the task has completed.
* Adds instructions to README
