### PR TITLE
Amend fake s3 port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
   fake-s3:
     image: localstack/localstack
     ports:
-      - "4572:4572"
+      - "4566:4566"
       - "8080:8080"
     environment:
       - SERVICES=s3
@@ -47,7 +47,7 @@ services:
       S3_BUCKET: backup-bucket
       AWS_ACCESS_KEY_ID: testkey
       AWS_SECRET_ACCESS_KEY: testsecret
-      BACKUP_ENDPOINT_URL: "http://fake-s3:4572"
+      BACKUP_ENDPOINT_URL: "http://fake-s3:4566"
 
 volumes:
   s3-data:


### PR DESCRIPTION
**WHAT**

Make the port 4566 not 4572 for the Fake S3 bucket service

**WHY**

Due to this change in localstack all ports are now 4566

https://github.com/localstack/localstack/issues/2983

Trello link: https://trello.com/c/icIT8t34