### PR TITLE
Changed Docker to install gpg instead of openssl in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN wget "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" \
  && rm awscli-bundle.zip \
  && ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws \
  && rm -r ./awscli-bundle
-RUN apk --no-cache add mariadb-client bash openssl
+RUN apk --no-cache add mariadb-client bash gpg
 
 COPY govwifi-backup.sh ./
 RUN chmod +x /govwifi-backup.sh


### PR DESCRIPTION
**WHAT**

Changed the install package section to install gpg instead of openssl

**WHY** 

We've changed the script to use gpg now so need that installed