### PR TITLE
Use correct gpg package name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN wget "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" \
  && rm awscli-bundle.zip \
  && ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws \
  && rm -r ./awscli-bundle
-RUN apk --no-cache add mariadb-client bash gpg
+RUN apk --no-cache add mariadb-client bash gnupg
 
 COPY govwifi-backup.sh ./
 RUN chmod +x /govwifi-backup.sh


### PR DESCRIPTION
**WHAT**

Package name correction

**WHY**

Package for `gpg` is called `gnupg` 