### PR TITLE
made filenames slightly more specific / rational

### DIFF
--- a/govwifi-backup.sh
+++ b/govwifi-backup.sh
@@ -15,21 +15,21 @@ echo "Starting encrypted backup of databases to S3 at `date`..."
 echo -n "STARTING SQL DUMP OF SESSIONS DB - "
 MYSQL_PWD="${WIFI_DB_PASS}" mysqldump -h "${WIFI_DB_HOSTNAME}" -u "${WIFI_DB_USER}" \
   --compress --quick --single-transaction --no-create-info --complete-insert "${WIFI_DB_NAME}" \
-  | gzip -c | gpg --symmetric --batch --yes --passphrase ${ENCRYPTION_KEY} | aws ${BACKUP_ENDPOINT_ARG} s3 cp - s3://"${S3_BUCKET}/wifi-backup-${STAMP_DATE}".sql.gz.gpg
+  | gzip -c | gpg --symmetric --batch --yes --passphrase ${ENCRYPTION_KEY} | aws ${BACKUP_ENDPOINT_ARG} s3 cp - s3://"${S3_BUCKET}/govwifi-backup-sessions-${STAMP_DATE}.sql.gz.gpg"
 STATUS1=$?
 [ $STATUS1 -eq 0 ] && echo COMPLETE || echo FAILED
 
 echo -n "STARTING SQL DUMP OF USERS DB - "
 MYSQL_PWD="${USERS_DB_PASS}" mysqldump -h "${USERS_DB_HOSTNAME}" -u "${USERS_DB_USER}" \
   --compress --quick --single-transaction --no-create-info --complete-insert "${USERS_DB_NAME}" \
-  | gzip -c | gpg --symmetric --batch --yes --passphrase ${ENCRYPTION_KEY} | aws ${BACKUP_ENDPOINT_ARG} s3 cp - s3://"${S3_BUCKET}/wifi-backup-user-details-${STAMP_DATE}".sql.gz.gpg
+  | gzip -c | gpg --symmetric --batch --yes --passphrase ${ENCRYPTION_KEY} | aws ${BACKUP_ENDPOINT_ARG} s3 cp - s3://"${S3_BUCKET}/govwifi-backup-user-details-${STAMP_DATE}.sql.gz.gpg"
 STATUS2=$?
 [ $STATUS2 -eq 0 ] && echo COMPLETE || echo FAILED
 
 echo -n "STARTING SQL DUMP OF ADMIN DB - "
 MYSQL_PWD="${ADMIN_DB_PASS}" mysqldump -h "${ADMIN_DB_HOSTNAME}" -u "${ADMIN_DB_USER}" \
   --compress --quick --single-transaction --no-create-info --complete-insert "${ADMIN_DB_NAME}" \
-  | gzip -c | gpg --symmetric --batch --yes --passphrase ${ENCRYPTION_KEY} | aws ${BACKUP_ENDPOINT_ARG} s3 cp - s3://"${S3_BUCKET}/wifi-backup-admin-${STAMP_DATE}".sql.gz.gpg
+  | gzip -c | gpg --symmetric --batch --yes --passphrase ${ENCRYPTION_KEY} | aws ${BACKUP_ENDPOINT_ARG} s3 cp - s3://"${S3_BUCKET}/govwifi-backup-admin-${STAMP_DATE}.sql.gz.gpg"
 STATUS3=$?
 [ $STATUS3 -eq 0 ] && echo COMPLETE || echo FAILED
 


### PR DESCRIPTION
## WHAT

Made the filenames a bit more "correct"
Added:
- added "gov" to the start of the filename (from wifi- to govwifi-)
- added "sessions-" to the filename for sessions db
- moved the end " to be after the extensions

## WHY

As these files are stored with others it makes them more obvious as to what they are 