### PR TITLE
Change Options On Mysql Dump To Make Restore Easier

### DIFF
--- a/govwifi-backup.sh
+++ b/govwifi-backup.sh
@@ -14,21 +14,21 @@ echo "Starting encrypted backup of databases to S3 at `date`..."
 # set the mysql pass pre command inline so not to appear in the proc list
 echo -n "STARTING SQL DUMP OF SESSIONS DB - "
 MYSQL_PWD="${WIFI_DB_PASS}" mysqldump -h "${WIFI_DB_HOSTNAME}" -u "${WIFI_DB_USER}" \
-  --compress --quick --single-transaction --no-create-info --complete-insert "${WIFI_DB_NAME}" \
+  --compress --quick --single-transaction --set-gtid-purged=OFF "${WIFI_DB_NAME}" \
   | gzip -c | gpg --symmetric --batch --yes --passphrase ${ENCRYPTION_KEY} | aws ${BACKUP_ENDPOINT_ARG} s3 cp - s3://"${S3_BUCKET}/govwifi-backup-sessions-${STAMP_DATE}.sql.gz.gpg"
 STATUS1=$?
 [ $STATUS1 -eq 0 ] && echo COMPLETE || echo FAILED
 
 echo -n "STARTING SQL DUMP OF USERS DB - "
 MYSQL_PWD="${USERS_DB_PASS}" mysqldump -h "${USERS_DB_HOSTNAME}" -u "${USERS_DB_USER}" \
-  --compress --quick --single-transaction --no-create-info --complete-insert "${USERS_DB_NAME}" \
+  --compress --quick --single-transaction --set-gtid-purged=OFF "${USERS_DB_NAME}" \
   | gzip -c | gpg --symmetric --batch --yes --passphrase ${ENCRYPTION_KEY} | aws ${BACKUP_ENDPOINT_ARG} s3 cp - s3://"${S3_BUCKET}/govwifi-backup-user-details-${STAMP_DATE}.sql.gz.gpg"
 STATUS2=$?
 [ $STATUS2 -eq 0 ] && echo COMPLETE || echo FAILED
 
 echo -n "STARTING SQL DUMP OF ADMIN DB - "
 MYSQL_PWD="${ADMIN_DB_PASS}" mysqldump -h "${ADMIN_DB_HOSTNAME}" -u "${ADMIN_DB_USER}" \
-  --compress --quick --single-transaction --no-create-info --complete-insert "${ADMIN_DB_NAME}" \
+  --compress --quick --single-transaction --set-gtid-purged=OFF "${ADMIN_DB_NAME}" \
   | gzip -c | gpg --symmetric --batch --yes --passphrase ${ENCRYPTION_KEY} | aws ${BACKUP_ENDPOINT_ARG} s3 cp - s3://"${S3_BUCKET}/govwifi-backup-admin-${STAMP_DATE}.sql.gz.gpg"
 STATUS3=$?
 [ $STATUS3 -eq 0 ] && echo COMPLETE || echo FAILED


### PR DESCRIPTION
**WHAT**
Edit options on mysqldump command. 

**WHY**
We want to create tables automatically if they don’t exist, as we will be restoring to an empty database.
We also do not need to restore GTIDs. More information on GTIDs can be found here: https://dev.mysql.com/doc/refman/8.0/en/replication-gtids-concepts.html
