### PR TITLE
Disable Column Statistics In Database Dumps

### DIFF
--- a/govwifi-backup.sh
+++ b/govwifi-backup.sh
@@ -14,21 +14,21 @@ echo "Starting encrypted backup of databases to S3 at `date`..."
 # set the mysql pass pre command inline so not to appear in the proc list
 echo -n "STARTING SQL DUMP OF SESSIONS DB - "
 MYSQL_PWD="${WIFI_DB_PASS}" mysqldump -h "${WIFI_DB_HOSTNAME}" -u "${WIFI_DB_USER}" \
-  --compress --quick --single-transaction --set-gtid-purged=OFF "${WIFI_DB_NAME}" \
+  --compress --quick --single-transaction --set-gtid-purged=OFF --column-statistics=0 "${WIFI_DB_NAME}" \
   | gzip -c | gpg --symmetric --batch --yes --passphrase ${ENCRYPTION_KEY} | aws ${BACKUP_ENDPOINT_ARG} s3 cp - s3://"${S3_BUCKET}/govwifi-backup-sessions-${STAMP_DATE}.sql.gz.gpg"
 STATUS1=$?
 [ $STATUS1 -eq 0 ] && echo COMPLETE || echo FAILED
 
 echo -n "STARTING SQL DUMP OF USERS DB - "
 MYSQL_PWD="${USERS_DB_PASS}" mysqldump -h "${USERS_DB_HOSTNAME}" -u "${USERS_DB_USER}" \
-  --compress --quick --single-transaction --set-gtid-purged=OFF "${USERS_DB_NAME}" \
+  --compress --quick --single-transaction --set-gtid-purged=OFF --column-statistics=0 "${USERS_DB_NAME}" \
   | gzip -c | gpg --symmetric --batch --yes --passphrase ${ENCRYPTION_KEY} | aws ${BACKUP_ENDPOINT_ARG} s3 cp - s3://"${S3_BUCKET}/govwifi-backup-user-details-${STAMP_DATE}.sql.gz.gpg"
 STATUS2=$?
 [ $STATUS2 -eq 0 ] && echo COMPLETE || echo FAILED
 
 echo -n "STARTING SQL DUMP OF ADMIN DB - "
 MYSQL_PWD="${ADMIN_DB_PASS}" mysqldump -h "${ADMIN_DB_HOSTNAME}" -u "${ADMIN_DB_USER}" \
-  --compress --quick --single-transaction --set-gtid-purged=OFF "${ADMIN_DB_NAME}" \
+  --compress --quick --single-transaction --set-gtid-purged=OFF --column-statistics=0 "${ADMIN_DB_NAME}" \
   | gzip -c | gpg --symmetric --batch --yes --passphrase ${ENCRYPTION_KEY} | aws ${BACKUP_ENDPOINT_ARG} s3 cp - s3://"${S3_BUCKET}/govwifi-backup-admin-${STAMP_DATE}.sql.gz.gpg"
 STATUS3=$?
 [ $STATUS3 -eq 0 ] && echo COMPLETE || echo FAILED


### PR DESCRIPTION
### What
Add flag on mysql dump command to disable column statistics.

### Why
Including column statistics in the database dump is causing an error
on restore, and we do not need to restore column statistics. More information on
column statistics can be found here:
https://dev.mysql.com/doc/mysql-infoschema-excerpt/8.0/en/information-schema-column-statistics-table.html

Link to Trello card: 
https://trello.com/c/hOVe5ire/1197-sub-task-test-encrypted-mysqldump-file-can-be-used-for-restore