### PR TITLE
Remove mysqldump flags

### DIFF
--- a/govwifi-backup.sh
+++ b/govwifi-backup.sh
@@ -14,21 +14,21 @@ echo "Starting encrypted backup of databases to S3 at `date`..."
 # set the mysql pass pre command inline so not to appear in the proc list
 echo -n "STARTING SQL DUMP OF SESSIONS DB - "
 MYSQL_PWD="${WIFI_DB_PASS}" mysqldump -h "${WIFI_DB_HOSTNAME}" -u "${WIFI_DB_USER}" \
-  --compress --quick --single-transaction --set-gtid-purged=OFF --column-statistics=0 "${WIFI_DB_NAME}" \
+  --compress --quick --single-transaction "${WIFI_DB_NAME}" \
   | gzip -c | gpg --symmetric --batch --yes --passphrase ${ENCRYPTION_KEY} | aws ${BACKUP_ENDPOINT_ARG} s3 cp - s3://"${S3_BUCKET}/govwifi-backup-sessions-${STAMP_DATE}.sql.gz.gpg"
 STATUS1=$?
 [ $STATUS1 -eq 0 ] && echo COMPLETE || echo FAILED
 
 echo -n "STARTING SQL DUMP OF USERS DB - "
 MYSQL_PWD="${USERS_DB_PASS}" mysqldump -h "${USERS_DB_HOSTNAME}" -u "${USERS_DB_USER}" \
-  --compress --quick --single-transaction --set-gtid-purged=OFF --column-statistics=0 "${USERS_DB_NAME}" \
+  --compress --quick --single-transaction "${USERS_DB_NAME}" \
   | gzip -c | gpg --symmetric --batch --yes --passphrase ${ENCRYPTION_KEY} | aws ${BACKUP_ENDPOINT_ARG} s3 cp - s3://"${S3_BUCKET}/govwifi-backup-user-details-${STAMP_DATE}.sql.gz.gpg"
 STATUS2=$?
 [ $STATUS2 -eq 0 ] && echo COMPLETE || echo FAILED
 
 echo -n "STARTING SQL DUMP OF ADMIN DB - "
 MYSQL_PWD="${ADMIN_DB_PASS}" mysqldump -h "${ADMIN_DB_HOSTNAME}" -u "${ADMIN_DB_USER}" \
-  --compress --quick --single-transaction --set-gtid-purged=OFF --column-statistics=0 "${ADMIN_DB_NAME}" \
+  --compress --quick --single-transaction "${ADMIN_DB_NAME}" \
   | gzip -c | gpg --symmetric --batch --yes --passphrase ${ENCRYPTION_KEY} | aws ${BACKUP_ENDPOINT_ARG} s3 cp - s3://"${S3_BUCKET}/govwifi-backup-admin-${STAMP_DATE}.sql.gz.gpg"
 STATUS3=$?
 [ $STATUS3 -eq 0 ] && echo COMPLETE || echo FAILED


### PR DESCRIPTION
### What
Remove mysqldump flags

### Why
Hmm ok so I have confused myself with this...The docker container we are using to run the tests is using mariadb-client and not mysql-client  https://github.com/alphagov/govwifi-database-backup/blob/master/Dockerfile#L8. I assumed we were using the mysql-client version of mysqldump when I added the flags to mysqldump in the previous commits:

https://github.com/alphagov/govwifi-database-backup/pull/20
https://github.com/alphagov/govwifi-database-backup/pull/18

This difference is important, because the mariadb version of mysqldump accepts different flags. Turns out the two flags I added previously don’t exist in this version.


