### PR TITLE
Decouple from tech-ops repo and use set_pipeline command

### DIFF
--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -42,12 +42,6 @@ resource_types:
   source:
     repository: teliaoss/github-pr-resource
 
-resources:
-  - name: tech-ops
-    type: git
-    source:
-      uri: https://github.com/alphagov/tech-ops.git
-
   - name: govwifi-database-backup
     type: git
     source:
@@ -79,19 +73,10 @@ jobs:
   - name: self-update
     serial: true
     plan:
-    - get: tech-ops
-      params:
-        submodules: none
     - get: govwifi-database-backup
       trigger: true
-    - task: set-pipelines
-      file: tech-ops/ci/tasks/self-updating-pipeline.yaml
-      input_mapping: {repository: govwifi-database-backup}
-      params:
-        CONCOURSE_TEAM: govwifi
-        CONCOURSE_PASSWORD: ((readonly_local_user_password))
-        PIPELINE_PATH: ci/pipelines/pr.yml
-        PIPELINE_NAME: database-backup-pr
+    - set_pipeline: database-backup-pr
+      - file: govwifi-database-backup/ci/pipeline.yml
 
   - name: lint & test
     interruptible: true

--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -76,7 +76,7 @@ jobs:
     - get: govwifi-database-backup
       trigger: true
     - set_pipeline: database-backup-pr
-      - file: govwifi-database-backup/ci/pipeline.yml
+      file: govwifi-database-backup/ci/pipeline.yml
 
   - name: lint & test
     interruptible: true


### PR DESCRIPTION
### What

Remove references to `tech-ops` repo and use `set_pipeline` command instead of `set-pipelines` task.

### Why

* We no longer need to point to tech-ops since we're creating our own GovWifi Concourse.
* `set_pipeline` is the built in functionality from Concourse, the alternative approach we were using was deprecated.
