### PR TITLE
Test GitHub actions

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -2,10 +2,10 @@ name: govwifi-database-backup test
 on:
   push:
     branches:
-      - test-github-actions
+      - master
   pull_request:
     branches:
-      - test-github-actions
+      - master
 
 jobs:
   test:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,0 +1,16 @@
+name: govwifi-database-backup test
+on:
+  push:
+    branches:
+      - test-github-actions
+  pull_request:
+    branches:
+      - test-github-actions
+
+jobs:
+  test:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run tests
+        run: make test


### PR DESCRIPTION
### What
Setup a github action workflow and test it.
Please note: there is currently no 'make lint' coded, this can be added at some later date.

### Why
This is part of the work to migrate from Concourse to Github Actions so that we can decommission GovWifi Concourse and save taxpayer funds.

Link to Trello card (if applicable): 
https://trello.com/c/uWdNRbsg/1180-fix-database-backup-pr-pipeline-ex-lets-migrate-this-to-github-actions-as-a-spike