### PR TITLE
Add platform to docker-compose to make the build compatible with M1 arch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3.4'
 
 services:
   db:
+    platform: 'linux/x86_64'
     build: ./mysql
     environment:
       MYSQL_ROOT_PASSWORD: root


### PR DESCRIPTION
### What
Add platform to docker-compose to make the build compatible with M1 arch
### Why
We have a lot of devs with Macs with M1 processor. This makes the repo compatible.
