### PR TITLE
Add the location of the backup task schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,7 @@ The following environment variables are required:
 ## Logging & Metrics
 
 The successful completion of the backup is logged using Cloudwatch Logs and used to create a metric filter with relevant alerting.
+
+## Scheduling
+
+The task is scheduled in the relevant AWS Account, ECS, Clusters (staging-api-cluster), Scheduled Tasks.


### PR DESCRIPTION
### What
Add the location of the backup schedule to our README.

### Why
The schedule is not in a logical place.
