### PR TITLE
Fix Error With Github Actions Tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 build:
 	docker-compose down
-	docker-compose up -d db fake-s3
-	docker-compose build
+	docker-compose up --build -d db fake-s3
+	docker-compose exec -T fake-s3 awslocal s3 mb s3://backup-bucket &> /dev/null
 	./mysql/wait_for_services & wait
 	docker-compose up app
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Backups are scheduled to run nightly and target replica instances. This is in ad
 
 The backup script runs as a scheduled container task using Amazon ECS.
 
+The [Dockerfile](./Dockerfile) is used when creating the ECR image which is deployed to our ECS containers
+
+The [docker-compose.yml](./docker-compose.yml) file is used for running github actions tests unit tests. The Dockerfile and the docker compose file are independent of each other and perform separate functions (but are both necessary). 
+
 ## Getting started
 
 To build configure and run the application via docker-compose:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,6 @@ services:
       - AWS_SECRET_ACCESS_KEY=testsecret
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - ./fake-s3:/docker-entrypoint-initaws.d
       - s3-data:/tmp/localstack
 
   app:

--- a/fake-s3/s3.sh
+++ b/fake-s3/s3.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-echo "Init localstack s3"
-awslocal s3 mb s3://backup-bucket


### PR DESCRIPTION
Fix error with github actions tests (unit tests). The tests were failing because the dummy s3 bucket was not being created. The script that creates the bucket was never being called. Added a line that runs the command for creating the local dummy S3 bucket (used for simulating how the script will behave in AWS).

Removed an unnecessary volume from the "fake-s3" container, and an unnecessary directory and script. This script was never called.

Added extra explanation to Readme about the different roles of the Dockerfile vs docker-compose.yml files

### What
Describe the change

### Why
Describe why the change was necessary


Link to Trello card (if applicable): 
