### PR TITLE
Upgrade Docker Container To Mysql 8

### DIFF
--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -1,3 +1,3 @@
-FROM mysql:5.7
+FROM mysql:8.0
 
 ADD schema.sql /docker-entrypoint-initdb.d


### PR DESCRIPTION
### What
Upgrade Docker Container To Mysql 8

### Why
Our databases are now all on mysql 8.


