### PR TITLE
Fix docker container errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,7 @@
 FROM python:3-alpine
 
-RUN wget "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" \
- && unzip awscli-bundle.zip \
- && rm awscli-bundle.zip \
- && ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws \
- && rm -r ./awscli-bundle
-RUN apk --no-cache add mariadb-client bash gnupg
+RUN apk add aws-cli
+RUN apk --no-cache add mariadb-connector-c mariadb-client bash gnupg
 
 COPY govwifi-backup.sh ./
 RUN chmod +x /govwifi-backup.sh


### PR DESCRIPTION
### What
Problem with AWS cli fixed by installing via apk instead of wget https://github.com/aws/aws-cli/issues/8036

Problem with Maria DB client fixed by installing additional package as recommended: https://community.home-assistant.io/t/usr-lib-mariadb-plugin-caching-sha2-password-so-cannot-be-found/439973/7

### Why
The docker container was failing to build

Link to Jira card (if applicable): https://technologyprogramme.atlassian.net/browse/GW-1451
